### PR TITLE
changed to use HTTPS in docs to get the hosted css

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You will need to add the domains that you want this to apply to yourself if you 
 - Install the [Simple Theme Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Simple+Theme+Plugin) on your Jenkins Server
 - Click `Manage Jenkins`
 - Click `Configure System` and scroll to `Theme` section
-- Specify the URL of `http://camalot.github.io/jenkins-dark-stylish/jenkins-dark.min.css` for the CSS
+- Specify the URL of `https://camalot.github.io/jenkins-dark-stylish/jenkins-dark.min.css` for the CSS
 - Click `Save`
 - Profit!
 


### PR DESCRIPTION
- fixes #33
- Changed the docs to use `https` when using the hosted css file. Should always use the `https`, no reason not to. 